### PR TITLE
Refine station contexts and logging

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import logger from '../utils/logger';
 
 export interface AuthenticatedRequest extends Request {
   apiKey?: string;
@@ -19,7 +20,9 @@ export function apiKeyAuth(req: AuthenticatedRequest, res: Response, next: NextF
   const validApiKeys = (process.env.VALID_API_KEYS || '').split(',').filter(Boolean);
 
   if (validApiKeys.length === 0) {
-    console.warn('⚠️ No API keys configured. Authentication is disabled.');
+    logger.warn('⚠️ No API keys configured. Authentication is disabled.', {
+      context: 'apiKeyAuth'
+    });
     req.apiKey = apiKey;
     next();
     return;


### PR DESCRIPTION
## Summary
- replace the API-key console warning in the auth middleware with the shared logger implementation
- adopt the shared Station2Context type within the conceptual analysis station to drive prompt generation
- build and consume a typed Station3Context inside the network builder inference engines for richer prompts

## Testing
- npm run lint *(fails: ESLint configuration file eslint.config.js is missing)*
- npm run type-check *(fails: npm script "type-check" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68df6361d8d88328afbe26f2e89822df